### PR TITLE
Dispose bug fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,9 +82,6 @@ install:
 before_script:
   # Wait for emulator fully-booted and disable animations
   - travis_wait 30 android-wait-for-emulator
-  - adb shell settings put global window_animation_scale 0 &
-  - adb shell settings put global transition_animation_scale 0 &
-  - adb shell settings put global animator_duration_scale 0 &
   - sleep 30
   - adb shell input keyevent 82 &
   - adb devices

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,6 @@ before_script:
   - android-wait-for-emulator
   - adb shell input keyevent 82
 
-install: travis_wait mvn install
-
 notifications:
   email: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,10 @@ before_install:
 - mkdir "$ANDROID_HOME/licenses" || true
 - echo "d56f5187479451eabf01fb78af6dfcb131a6481e" > "$ANDROID_HOME/licenses/android-sdk-license"
 - chmod +x gradlew
-- echo no | avdmanager create avd --force -n test -k "system-images;android-22;default;armeabi-v7a"
-- $ANDROID_HOME/emulator/emulator -avd test -no-audio -no-window &
 
 before_script:
+  - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
+  - emulator -avd test -no-skin -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,43 +1,17 @@
 language: android
-
 android:
   components:
-    # Update tools and then platform-tools explicitly so lint gets an updated database. Can be removed once 3.0 is out.
-    - tools
-    - platform-tools
-
-jdk:
-  - oraclejdk8
-
-before_install:
-  # Install SDK license so Android Gradle plugin can install deps.
-  - mkdir "$ANDROID_HOME/licenses" || true
-  - echo "d56f5187479451eabf01fb78af6dfcb131a6481e" > "$ANDROID_HOME/licenses/android-sdk-license"
-  - sdkmanager tools
-  # Install the system image
-  - sdkmanager "system-images;android-18;default;armeabi-v7a"
-  # Create and start emulator for the script. Meant to race the install task.
-  - echo no | avdmanager create avd --force -n test -k "system-images;android-18;default;armeabi-v7a"
-  - $ANDROID_HOME/emulator/emulator -avd test -no-audio -no-window &
-
-install: ./gradlew ":vangogh:assemble" --stacktrace
-
+    - build-tools-19.0.3
+    - $ANDROID_TARGET
+    - sys-img-armeabi-v7a-$ANDROID_TARGET
+    - extra-android-support
+    - extra-android-m2repository
+    - extra-google-m2repository
+env:
+  matrix:
+    - ANDROID_TARGET=android-19  ANDROID_ABI=armeabi-v7a
 before_script:
+  - echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI
+  - emulator -avd test -no-skin -no-audio -no-window &
   - android-wait-for-emulator
-  - adb shell input keyevent 82
-
-script:
-  - ./gradlew ":vangogh:build" ":vangogh:connectedCheck" --stacktrace
-
-branches:
-  except:
-    - gh-pages
-
-notifications:
-  email: false
-
-sudo: false
-
-cache:
-  directories:
-    - $HOME/.gradle
+  - adb shell input keyevent 82 &

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - echo no | avdmanager create avd --force -n test -k "system-images;android-18;default;armeabi-v7a"
   - $ANDROID_HOME/emulator/emulator -avd test -no-audio -no-window &
 
-install: ./gradlew ":$MODULE:assemble" --stacktrace
+install: ./gradlew ":vangogh:assemble" --stacktrace
 
 before_script:
   - android-wait-for-emulator

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,14 @@ before_install:
 - mkdir "$ANDROID_HOME/licenses" || true
 - echo "d56f5187479451eabf01fb78af6dfcb131a6481e" > "$ANDROID_HOME/licenses/android-sdk-license"
 - chmod +x gradlew
+- echo no | avdmanager create avd --force -n test -k "system-images;android-22;default;armeabi-v7a"
+- $ANDROID_HOME/emulator/emulator -avd test -no-audio -no-window &
 
 before_script:
-  - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
-  - emulator -avd test -no-skin -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82
+
+install: travis_wait mvn install
 
 notifications:
   email: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,90 @@
+# This script is based on this example:
+# https://stackoverflow.com/questions/42731625/travis-ci-failed-because-cannot-accept-license-constrain-layout/42736695#42736695
+# See also:
+# https://github.com/travis-ci/travis-ci/issues/6122 Android - Missing emulator ABI due to bad SDK Tools version
 language: android
-android:
-  components:
-    - build-tools-19.0.3
-    - $ANDROID_TARGET
-    - sys-img-armeabi-v7a-$ANDROID_TARGET
-    - extra-android-support
-    - extra-android-m2repository
-    - extra-google-m2repository
+jdk: oraclejdk8
+sudo: required # false for Container-Based Infrastructure, required for Sudo-enabled Infrastructure
+dist: trusty
+group: edge  # Add this
+
 env:
-  matrix:
-    - ANDROID_TARGET=android-19  ANDROID_ABI=armeabi-v7a
+  global:
+    - ANDROID_BUILD_TOOLS_VERSION=25.0.3 # Match build-tools version used in build.gradle
+    - PROJECT_DIR=${TRAVIS_BUILD_DIR} # Project directory
+    - EMULATOR_API_LEVEL=25 # Android API level 25 by default
+    - EMULATOR_TAG=google_apis # Google APIs by default, alternatively use default
+    - EMULATOR_ABI=armeabi-v7a # ARM ABI v7a by default
+    - QEMU_AUDIO_DRV=none # Disable emulator audio to avoid warning
+    - GRADLE_USER_HOME="${TRAVIS_BUILD_DIR}/gradle" # Change location for Gradle Wrapper and cache
+    - ANDROID_HOME=/usr/local/android-sdk-25.2.3 # Depends on the cookbooks version used in the VM
+    - TOOLS=${ANDROID_HOME}/tools # PATH order matters, exists more than one emulator script
+    - PATH=${ANDROID_HOME}:${ANDROID_HOME}/emulator:${TOOLS}:${TOOLS}/bin:${ANDROID_HOME}/platform-tools:${PATH}
+    - ADB_INSTALL_TIMEOUT=20 # minutes (2 minutes by default)
+
+android:
+  components: # Cookbooks version: https://github.com/travis-ci/travis-cookbooks/tree/94f697cf01ee1e5a274fca1d0719101969953098/community-cookbooks/android-sdk
+    - tools # Update preinstalled tools from revision 24.0.2 to 24.4.1
+    - build-tools-${ANDROID_BUILD_TOOLS_VERSION}
+    - platform-tools # Update platform-tools to revision 25.0.3+
+    - tools # Update tools from revision 24.4.1 to 25.2.5
+
+#matrix:
+#  include: # More Emulator API levels to build in parallel
+#    - env: EMULATOR_API_LEVEL=23
+#  allow_failures:
+#    - env: EMULATOR_API_LEVEL=23
+#  fast_finish: false
+
+before_cache:
+  - rm -f ${TRAVIS_BUILD_DIR}/gradle/caches/modules-2/modules-2.lock # Avoid to repack it due locks
+  - rm -f ${TRAVIS_BUILD_DIR}/gradle/caches/3.3/classAnalysis/classAnalysis.lock
+  - rm -f ${TRAVIS_BUILD_DIR}/gradle/caches/3.3/jarSnapshots/jarSnapshots.lock
+
+cache:
+  directories:
+    - ${TRAVIS_BUILD_DIR}/gradle/caches/
+    - ${TRAVIS_BUILD_DIR}/gradle/wrapper/dists/
+
+notifications:
+  email: false
 
 before_install:
-  # Install SDK license so Android Gradle plugin can install deps.
-  - mkdir "$ANDROID_HOME/licenses" || true
-  - echo "d56f5187479451eabf01fb78af6dfcb131a6481e" > "$ANDROID_HOME/licenses/android-sdk-license"
+  - export EMULATOR="system-images;android-${EMULATOR_API_LEVEL};${EMULATOR_TAG};${EMULATOR_ABI}" # Used to install/create emulator
+  - echo 'count=0' > /home/travis/.android/repositories.cfg # Avoid warning
+  - ls -la ${TOOLS}/**/*
+
+install:
+  # List and delete unnecessary components to free space
+  - sdkmanager --list || true
+  - sdkmanager --uninstall "extras;google;google_play_services"
+  # Update sdk tools to latest version and install/update components
+  - echo yes | sdkmanager "tools"
+  - echo yes | sdkmanager "platforms;android-25" # Latest platform required by SDK tools
+  - echo yes | sdkmanager "platforms;android-${EMULATOR_API_LEVEL}" # Android platform required by emulator
+  - echo yes | sdkmanager "extras;android;m2repository"
+  - echo yes | sdkmanager "extras;google;m2repository"
+  - echo yes | sdkmanager "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.2"
+  - echo yes | sdkmanager "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.2"
+  - echo yes | sdkmanager "${EMULATOR}" # Install emulator system image
+  # Create and start emulator
+  - echo no | avdmanager create avd -n acib -k "${EMULATOR}" -f --abi "${EMULATOR_ABI}" --tag "${EMULATOR_TAG}"
+  - emulator -avd acib -engine classic -no-window -camera-back none -camera-front none -verbose -memory 2048 &
+  # Start adbd, wait for device connected and show android serial
+  - adb wait-for-device get-serialno
+  # Show version and download Gradle Wrapper if it's not already cached
+  - cd ${PROJECT_DIR} && ./gradlew --version
+  # Clean project and download missing dependencies and components
+  - cd ${PROJECT_DIR} && ./gradlew clean build
+  # Check components status
+  - sdkmanager --list || true
 
 before_script:
-  - echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI
-  - emulator -avd test -no-skin -no-audio -no-window &
-  - android-wait-for-emulator
+  # Wait for emulator fully-booted and disable animations
+  - travis_wait 30 android-wait-for-emulator
+  - adb shell settings put global window_animation_scale 0 &
+  - adb shell settings put global transition_animation_scale 0 &
+  - adb shell settings put global animator_duration_scale 0 &
+  - sleep 30
   - adb shell input keyevent 82 &
+  - adb devices

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,43 @@
-# Disabling sudo moves build to the Container Based Infrastructure on Travis CI
-sudo: false
-
 language: android
-jdk: oraclejdk8
 
 android:
   components:
-    - platform-tools
+    # Update tools and then platform-tools explicitly so lint gets an updated database. Can be removed once 3.0 is out.
     - tools
-    - android-22
-    - build-tools-23.0.3
-    - extra-android-m2repository
-    - extra-android-support
-    - sys-img-armeabi-v7a-android-22
+    - platform-tools
+
+jdk:
+  - oraclejdk8
 
 before_install:
-- mkdir "$ANDROID_HOME/licenses" || true
-- echo "d56f5187479451eabf01fb78af6dfcb131a6481e" > "$ANDROID_HOME/licenses/android-sdk-license"
-- chmod +x gradlew
+  # Install SDK license so Android Gradle plugin can install deps.
+  - mkdir "$ANDROID_HOME/licenses" || true
+  - echo "d56f5187479451eabf01fb78af6dfcb131a6481e" > "$ANDROID_HOME/licenses/android-sdk-license"
+  - sdkmanager tools
+  # Install the system image
+  - sdkmanager "system-images;android-18;default;armeabi-v7a"
+  # Create and start emulator for the script. Meant to race the install task.
+  - echo no | avdmanager create avd --force -n test -k "system-images;android-18;default;armeabi-v7a"
+  - $ANDROID_HOME/emulator/emulator -avd test -no-audio -no-window &
+
+install: ./gradlew ":$MODULE:assemble" --stacktrace
 
 before_script:
-  - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
-  - emulator -avd test -no-skin -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82
 
+script:
+  - ./gradlew ":vangogh:build" ":vangogh:connectedCheck" --stacktrace
+
+branches:
+  except:
+    - gh-pages
+
 notifications:
-  email: true
+  email: false
+
+sudo: false
 
 cache:
   directories:
-    - $HOME/.m2
     - $HOME/.gradle

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,12 @@ android:
 env:
   matrix:
     - ANDROID_TARGET=android-19  ANDROID_ABI=armeabi-v7a
+
+before_install:
+  # Install SDK license so Android Gradle plugin can install deps.
+  - mkdir "$ANDROID_HOME/licenses" || true
+  - echo "d56f5187479451eabf01fb78af6dfcb131a6481e" > "$ANDROID_HOME/licenses/android-sdk-license"
+
 before_script:
   - echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI
   - emulator -avd test -no-skin -no-audio -no-window &

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,87 +1,34 @@
-# This script is based on this example:
-# https://stackoverflow.com/questions/42731625/travis-ci-failed-because-cannot-accept-license-constrain-layout/42736695#42736695
-# See also:
-# https://github.com/travis-ci/travis-ci/issues/6122 Android - Missing emulator ABI due to bad SDK Tools version
+# Disabling sudo moves build to the Container Based Infrastructure on Travis CI
+sudo: false
+
 language: android
 jdk: oraclejdk8
-sudo: required # false for Container-Based Infrastructure, required for Sudo-enabled Infrastructure
-dist: trusty
-group: edge  # Add this
-
-env:
-  global:
-    - ANDROID_BUILD_TOOLS_VERSION=25.0.3 # Match build-tools version used in build.gradle
-    - PROJECT_DIR=${TRAVIS_BUILD_DIR} # Project directory
-    - EMULATOR_API_LEVEL=25 # Android API level 25 by default
-    - EMULATOR_TAG=google_apis # Google APIs by default, alternatively use default
-    - EMULATOR_ABI=armeabi-v7a # ARM ABI v7a by default
-    - QEMU_AUDIO_DRV=none # Disable emulator audio to avoid warning
-    - GRADLE_USER_HOME="${TRAVIS_BUILD_DIR}/gradle" # Change location for Gradle Wrapper and cache
-    - ANDROID_HOME=/usr/local/android-sdk-25.2.3 # Depends on the cookbooks version used in the VM
-    - TOOLS=${ANDROID_HOME}/tools # PATH order matters, exists more than one emulator script
-    - PATH=${ANDROID_HOME}:${ANDROID_HOME}/emulator:${TOOLS}:${TOOLS}/bin:${ANDROID_HOME}/platform-tools:${PATH}
-    - ADB_INSTALL_TIMEOUT=20 # minutes (2 minutes by default)
 
 android:
-  components: # Cookbooks version: https://github.com/travis-ci/travis-cookbooks/tree/94f697cf01ee1e5a274fca1d0719101969953098/community-cookbooks/android-sdk
-    - tools # Update preinstalled tools from revision 24.0.2 to 24.4.1
-    - build-tools-${ANDROID_BUILD_TOOLS_VERSION}
-    - platform-tools # Update platform-tools to revision 25.0.3+
-    - tools # Update tools from revision 24.4.1 to 25.2.5
+  components:
+    - platform-tools
+    - tools
+    - android-22
+    - build-tools-23.0.3
+    - extra-android-m2repository
+    - extra-android-support
+    - sys-img-armeabi-v7a-android-22
 
-#matrix:
-#  include: # More Emulator API levels to build in parallel
-#    - env: EMULATOR_API_LEVEL=23
-#  allow_failures:
-#    - env: EMULATOR_API_LEVEL=23
-#  fast_finish: false
+before_install:
+- mkdir "$ANDROID_HOME/licenses" || true
+- echo "d56f5187479451eabf01fb78af6dfcb131a6481e" > "$ANDROID_HOME/licenses/android-sdk-license"
+- chmod +x gradlew
 
-before_cache:
-  - rm -f ${TRAVIS_BUILD_DIR}/gradle/caches/modules-2/modules-2.lock # Avoid to repack it due locks
-  - rm -f ${TRAVIS_BUILD_DIR}/gradle/caches/3.3/classAnalysis/classAnalysis.lock
-  - rm -f ${TRAVIS_BUILD_DIR}/gradle/caches/3.3/jarSnapshots/jarSnapshots.lock
+before_script:
+  - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
+  - emulator -avd test -no-skin -no-audio -no-window &
+  - android-wait-for-emulator
+  - adb shell input keyevent 82
+
+notifications:
+  email: true
 
 cache:
   directories:
-    - ${TRAVIS_BUILD_DIR}/gradle/caches/
-    - ${TRAVIS_BUILD_DIR}/gradle/wrapper/dists/
-
-notifications:
-  email: false
-
-before_install:
-  - export EMULATOR="system-images;android-${EMULATOR_API_LEVEL};${EMULATOR_TAG};${EMULATOR_ABI}" # Used to install/create emulator
-  - echo 'count=0' > /home/travis/.android/repositories.cfg # Avoid warning
-  - ls -la ${TOOLS}/**/*
-
-install:
-  # List and delete unnecessary components to free space
-  - sdkmanager --list || true
-  - sdkmanager --uninstall "extras;google;google_play_services"
-  # Update sdk tools to latest version and install/update components
-  - echo yes | sdkmanager "tools"
-  - echo yes | sdkmanager "platforms;android-25" # Latest platform required by SDK tools
-  - echo yes | sdkmanager "platforms;android-${EMULATOR_API_LEVEL}" # Android platform required by emulator
-  - echo yes | sdkmanager "extras;android;m2repository"
-  - echo yes | sdkmanager "extras;google;m2repository"
-  - echo yes | sdkmanager "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.2"
-  - echo yes | sdkmanager "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.2"
-  - echo yes | sdkmanager "${EMULATOR}" # Install emulator system image
-  # Create and start emulator
-  - echo no | avdmanager create avd -n acib -k "${EMULATOR}" -f --abi "${EMULATOR_ABI}" --tag "${EMULATOR_TAG}"
-  - emulator -avd acib -engine classic -no-window -camera-back none -camera-front none -verbose -memory 2048 &
-  # Start adbd, wait for device connected and show android serial
-  - adb wait-for-device get-serialno
-  # Show version and download Gradle Wrapper if it's not already cached
-  - cd ${PROJECT_DIR} && ./gradlew --version
-  # Clean project and download missing dependencies and components
-  - cd ${PROJECT_DIR} && ./gradlew clean build
-  # Check components status
-  - sdkmanager --list || true
-
-before_script:
-  # Wait for emulator fully-booted and disable animations
-  - travis_wait 30 android-wait-for-emulator
-  - sleep 30
-  - adb shell input keyevent 82 &
-  - adb devices
+    - $HOME/.m2
+    - $HOME/.gradle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 Change Log
 ==========
 
+Version 0.1.1 *(2017-11-20)*
+----------------------------
+* Fixes `NullPointerException` being thrown when animation disposed midway. ([#10](https://github.com/PSPDFKit-labs/VanGogh/issues/10))
+
+
 Version 0.1.0 *(2017-11-09)*
 ----------------------------
-
 Initial release.

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -13,8 +13,7 @@ ext.versions = [
         // Test dependencies
         junit              : '4.12',
         espresso           : '2.2.2',
-        robolectric        : '3.4.2',
-        mockito            : '2.12.0'
+        robolectric        : '3.4.2'
 ]
 
 ext.gradlePlugins = [
@@ -31,6 +30,4 @@ ext.libraries = [
         junit           : "junit:junit:$versions.junit",
         espressoCore    : "com.android.support.test.espresso:espresso-core:$versions.espresso",
         robolectric     : "org.robolectric:robolectric:$versions.robolectric",
-        mockitoCore     : "org.mockito:mockito-core:$versions.mockito",
-        mockitoAndroid  : "org.mockito:mockito-android:$versions.mockito"
 ]

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -13,7 +13,8 @@ ext.versions = [
         // Test dependencies
         junit              : '4.12',
         espresso           : '2.2.2',
-        robolectric        : '3.4.2'
+        robolectric        : '3.4.2',
+        mockito            : '2.12.0'
 ]
 
 ext.gradlePlugins = [
@@ -29,5 +30,7 @@ ext.libraries = [
         // Test dependencies
         junit           : "junit:junit:$versions.junit",
         espressoCore    : "com.android.support.test.espresso:espresso-core:$versions.espresso",
-        robolectric     : "org.robolectric:robolectric:$versions.robolectric"
+        robolectric     : "org.robolectric:robolectric:$versions.robolectric",
+        mockitoCore     : "org.mockito:mockito-core:$versions.mockito",
+        mockitoAndroid  : "org.mockito:mockito-android:$versions.mockito"
 ]

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ org.gradle.jvmargs=-Xmx1536m
 # org.gradle.parallel=true
 
 GROUP=com.pspdfkit-labs
-VERSION_NAME=0.2.0-SNAPSHOT
+VERSION_NAME=0.1.1-SNAPSHOT
 
 POM_DESCRIPTION=Android view animations powered by RxJava2.
 POM_URL=https://github.com/PSPDFKit-labs/VanGogh

--- a/vangogh/build.gradle
+++ b/vangogh/build.gradle
@@ -33,10 +33,12 @@ dependencies {
 
     // Android test dependencies
     androidTestCompile libraries.espressoCore
+    androidTestCompile libraries.mockitoAndroid
 
     // Test dependencies
     testCompile libraries.junit
     testCompile libraries.robolectric
+    testCompile libraries.mockitoCore
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/vangogh/build.gradle
+++ b/vangogh/build.gradle
@@ -34,12 +34,12 @@ dependencies {
 
     // Android test dependencies
     androidTestCompile libraries.espressoCore
-    //androidTestCompile libraries.mockitoAndroid
+    androidTestCompile 'com.google.dexmaker:dexmaker:1.2'
+    androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.2'
 
     // Test dependencies
     testCompile libraries.junit
     testCompile libraries.robolectric
-    //testCompile libraries.mockitoCore
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/vangogh/build.gradle
+++ b/vangogh/build.gradle
@@ -30,15 +30,16 @@ dependencies {
     // Library dependencies
     compile libraries.supportAppCompat
     compile libraries.rxJava
+    compile libraries.rxAndroid
 
     // Android test dependencies
     androidTestCompile libraries.espressoCore
-    androidTestCompile libraries.mockitoAndroid
+    //androidTestCompile libraries.mockitoAndroid
 
     // Test dependencies
     testCompile libraries.junit
     testCompile libraries.robolectric
-    testCompile libraries.mockitoCore
+    //testCompile libraries.mockitoCore
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/vangogh/src/androidTest/java/com/pspdfkit/labs/vangogh/api/BaseAnimationsTest.java
+++ b/vangogh/src/androidTest/java/com/pspdfkit/labs/vangogh/api/BaseAnimationsTest.java
@@ -38,6 +38,8 @@ public abstract class BaseAnimationsTest {
     public void setUp() {
         view = activityRule.getActivity().findViewById(com.pspdfkit.labs.vangogh.test.R.id.view);
         o = new TestObserver();
+        o.assertNotSubscribed();
+        o.assertNotComplete();
     }
 
     @After

--- a/vangogh/src/androidTest/java/com/pspdfkit/labs/vangogh/api/BaseAnimationsTest.java
+++ b/vangogh/src/androidTest/java/com/pspdfkit/labs/vangogh/api/BaseAnimationsTest.java
@@ -55,8 +55,7 @@ public abstract class BaseAnimationsTest {
     protected void assertTestObserverCompletedAfterDuration(long durationMs) throws InterruptedException {
         o.await(durationMs - 150, TimeUnit.MILLISECONDS);
         o.assertNotComplete();
-
-        o.awaitDone(2 * durationMs, TimeUnit.SECONDS);
+        o.awaitTerminalEvent();
         o.assertComplete();
     }
 

--- a/vangogh/src/androidTest/java/com/pspdfkit/labs/vangogh/api/FadeAnimationsTest.java
+++ b/vangogh/src/androidTest/java/com/pspdfkit/labs/vangogh/api/FadeAnimationsTest.java
@@ -22,7 +22,6 @@ public class FadeAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testFadeIn() throws Throwable {
-        o.assertNotComplete();
         activityRule.runOnUiThread(new Runnable() {
             @Override
             public void run() {
@@ -37,7 +36,6 @@ public class FadeAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testFadeInWithDuration() throws Throwable {
-        o.assertNotComplete();
         activityRule.runOnUiThread(new Runnable() {
             @Override
             public void run() {

--- a/vangogh/src/androidTest/java/com/pspdfkit/labs/vangogh/api/FadeAnimationsTest.java
+++ b/vangogh/src/androidTest/java/com/pspdfkit/labs/vangogh/api/FadeAnimationsTest.java
@@ -61,7 +61,6 @@ public class FadeAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testFadeInQuickly() throws Throwable {
-        o.assertNotComplete();
         activityRule.runOnUiThread(new Runnable() {
             @Override
             public void run() {
@@ -80,7 +79,6 @@ public class FadeAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testFadeInSlowly() throws Throwable {
-        o.assertNotComplete();
         activityRule.runOnUiThread(new Runnable() {
             @Override
             public void run() {
@@ -99,7 +97,6 @@ public class FadeAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testFadeOut() throws Throwable {
-        o.assertNotComplete();
         activityRule.runOnUiThread(new Runnable() {
             @Override
             public void run() {
@@ -113,7 +110,6 @@ public class FadeAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testFadeOutWithDuration() throws Throwable {
-        o.assertNotComplete();
         activityRule.runOnUiThread(new Runnable() {
             @Override
             public void run() {
@@ -137,7 +133,6 @@ public class FadeAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testFadeOutQuickly() throws Throwable {
-        o.assertNotComplete();
         fadeOutQuickly(view).subscribe(o);
         assertTestObserverCompletedAfterDuration(DURATION_QUICK);
         assertEquals(0f, view.getAlpha(), 0f);
@@ -150,7 +145,6 @@ public class FadeAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testFadeOutSlowly() throws Throwable {
-        o.assertNotComplete();
         activityRule.runOnUiThread(new Runnable() {
             @Override
             public void run() {
@@ -169,7 +163,6 @@ public class FadeAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testFadeToAlpha() throws Throwable {
-        o.assertNotComplete();
         activityRule.runOnUiThread(new Runnable() {
             @Override
             public void run() {
@@ -183,7 +176,6 @@ public class FadeAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testFadeToAlphaWithDuration() throws Throwable {
-        o.assertNotComplete();
         activityRule.runOnUiThread(new Runnable() {
             @Override
             public void run() {

--- a/vangogh/src/androidTest/java/com/pspdfkit/labs/vangogh/api/RotateAnimationsTest.java
+++ b/vangogh/src/androidTest/java/com/pspdfkit/labs/vangogh/api/RotateAnimationsTest.java
@@ -17,7 +17,6 @@ public class RotateAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testRotateTo() throws InterruptedException {
-        o.assertNotComplete();
         rotateTo(view, ROTATE_TO_DEGREES).subscribe(o);
         assertTestObserverCompletedAfterDuration(AnimationConstants.DURATION_DEFAULT);
         assertEquals(ROTATE_TO_DEGREES, view.getRotation(), 0.1f);
@@ -25,7 +24,6 @@ public class RotateAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testRotateToWithDuration() throws InterruptedException {
-        o.assertNotComplete();
         rotateTo(view, ROTATE_TO_DEGREES, CUSTOM_TEST_DURATION_MS).subscribe(o);
         assertTestObserverCompletedAfterDuration(CUSTOM_TEST_DURATION_MS);
         assertEquals(ROTATE_TO_DEGREES, view.getRotation(), 0.1f);
@@ -43,7 +41,6 @@ public class RotateAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testRotateQuicklyTo() throws InterruptedException {
-        o.assertNotComplete();
         rotateQuicklyTo(view, ROTATE_TO_DEGREES).subscribe(o);
         assertTestObserverCompletedAfterDuration(AnimationConstants.DURATION_QUICK);
         assertEquals(ROTATE_TO_DEGREES, view.getRotation(), 0.1f);
@@ -56,7 +53,6 @@ public class RotateAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testRotateSlowlyTo() throws InterruptedException {
-        o.assertNotComplete();
         rotateSlowlyTo(view, ROTATE_TO_DEGREES).subscribe(o);
         assertTestObserverCompletedAfterDuration(AnimationConstants.DURATION_SLOW);
         assertEquals(ROTATE_TO_DEGREES, view.getRotation(), 0.1f);
@@ -69,7 +65,6 @@ public class RotateAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testRotateBy() throws InterruptedException {
-        o.assertNotComplete();
         rotateBy(view, ROTATE_BY_DEGREES).andThen(rotateBy(view, ROTATE_BY_DEGREES)).subscribe(o);
         assertTestObserverCompletedAfterDuration(2 * AnimationConstants.DURATION_DEFAULT);
         assertEquals(2 * ROTATE_BY_DEGREES, view.getRotation(), 0.1f);
@@ -77,7 +72,6 @@ public class RotateAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testRotateByWithDuration() throws InterruptedException {
-        o.assertNotComplete();
         rotateBy(view, ROTATE_BY_DEGREES, CUSTOM_TEST_DURATION_MS).andThen(rotateBy(view, ROTATE_BY_DEGREES, CUSTOM_TEST_DURATION_MS)).subscribe(o);
         assertTestObserverCompletedAfterDuration(2 * CUSTOM_TEST_DURATION_MS);
         assertEquals(2 * ROTATE_BY_DEGREES, view.getRotation(), 0.1f);
@@ -95,7 +89,6 @@ public class RotateAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testRotateQuicklyBy() throws InterruptedException {
-        o.assertNotComplete();
         rotateQuicklyBy(view, ROTATE_BY_DEGREES).andThen(rotateQuicklyBy(view, ROTATE_BY_DEGREES)).subscribe(o);
         assertTestObserverCompletedAfterDuration(2 * AnimationConstants.DURATION_QUICK);
         assertEquals(2 * ROTATE_BY_DEGREES, view.getRotation(), 0.1f);
@@ -108,7 +101,6 @@ public class RotateAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testRotateSlowlyBy() throws InterruptedException {
-        o.assertNotComplete();
         rotateSlowlyBy(view, ROTATE_BY_DEGREES).andThen(rotateSlowlyBy(view, ROTATE_BY_DEGREES)).subscribe(o);
         assertTestObserverCompletedAfterDuration(2 * AnimationConstants.DURATION_SLOW);
         assertEquals(2 * ROTATE_BY_DEGREES, view.getRotation(), 0.1f);

--- a/vangogh/src/androidTest/java/com/pspdfkit/labs/vangogh/api/ScaleAnimationsTest.java
+++ b/vangogh/src/androidTest/java/com/pspdfkit/labs/vangogh/api/ScaleAnimationsTest.java
@@ -17,7 +17,6 @@ public class ScaleAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testScaleTo() throws InterruptedException {
-        o.assertNotComplete();
         scaleTo(view, SCALE_TO_VALUE).subscribe(o);
         assertTestObserverCompletedAfterDuration(AnimationConstants.DURATION_DEFAULT);
         assertEquals(SCALE_TO_VALUE, view.getScaleX(), 0.1f);
@@ -26,7 +25,6 @@ public class ScaleAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testScaleToWithDuration() throws InterruptedException {
-        o.assertNotComplete();
         scaleTo(view, SCALE_TO_VALUE, CUSTOM_TEST_DURATION_MS).subscribe(o);
         assertTestObserverCompletedAfterDuration(CUSTOM_TEST_DURATION_MS);
         assertEquals(SCALE_TO_VALUE, view.getScaleX(), 0.1f);
@@ -45,7 +43,6 @@ public class ScaleAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testScaleQuicklyTo() throws InterruptedException {
-        o.assertNotComplete();
         scaleQuicklyTo(view, SCALE_TO_VALUE).subscribe(o);
         assertTestObserverCompletedAfterDuration(AnimationConstants.DURATION_QUICK);
         assertEquals(SCALE_TO_VALUE, view.getScaleX(), 0.1f);
@@ -59,7 +56,6 @@ public class ScaleAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testScaleSlowlyTo() throws InterruptedException {
-        o.assertNotComplete();
         scaleSlowlyTo(view, SCALE_TO_VALUE).subscribe(o);
         assertTestObserverCompletedAfterDuration(AnimationConstants.DURATION_SLOW);
         assertEquals(SCALE_TO_VALUE, view.getScaleX(), 0.1f);
@@ -73,7 +69,6 @@ public class ScaleAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testScaleBy() throws InterruptedException {
-        o.assertNotComplete();
         scaleBy(view, SCALE_BY_VALUE).andThen(scaleBy(view, SCALE_BY_VALUE)).subscribe(o);
         assertTestObserverCompletedAfterDuration(AnimationConstants.DURATION_DEFAULT * 2);
         assertEquals(1 + 2 * SCALE_BY_VALUE, view.getScaleX(), 0.1f);
@@ -82,7 +77,6 @@ public class ScaleAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testScaleByWithDuration() throws InterruptedException {
-        o.assertNotComplete();
         scaleBy(view, SCALE_BY_VALUE, CUSTOM_TEST_DURATION_MS).andThen(scaleBy(view, SCALE_BY_VALUE, CUSTOM_TEST_DURATION_MS)).subscribe(o);
         assertTestObserverCompletedAfterDuration(CUSTOM_TEST_DURATION_MS * 2);
         assertEquals(1 + 2 * SCALE_BY_VALUE, view.getScaleX(), 0.1f);
@@ -101,7 +95,6 @@ public class ScaleAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testScaleQuicklyBy() throws InterruptedException {
-        o.assertNotComplete();
         scaleQuicklyBy(view, SCALE_BY_VALUE).andThen(scaleQuicklyBy(view, SCALE_BY_VALUE)).subscribe(o);
         assertTestObserverCompletedAfterDuration(AnimationConstants.DURATION_QUICK * 2);
         assertEquals(1 + 2 * SCALE_BY_VALUE, view.getScaleX(), 0.1f);
@@ -115,7 +108,6 @@ public class ScaleAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testScaleSlowlyBy() throws InterruptedException {
-        o.assertNotComplete();
         scaleSlowlyBy(view, SCALE_BY_VALUE).andThen(scaleSlowlyBy(view, SCALE_BY_VALUE)).subscribe(o);
         assertTestObserverCompletedAfterDuration(AnimationConstants.DURATION_SLOW * 2);
         assertEquals(1 + 2 * SCALE_BY_VALUE, view.getScaleX(), 0.1f);

--- a/vangogh/src/androidTest/java/com/pspdfkit/labs/vangogh/api/TranslateAnimationsTest.java
+++ b/vangogh/src/androidTest/java/com/pspdfkit/labs/vangogh/api/TranslateAnimationsTest.java
@@ -26,7 +26,6 @@ public class TranslateAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testTranslateTo() throws InterruptedException {
-        o.assertNotComplete();
         translateTo(view, TRANSLATE_TO_X_VALUE, TRANSLATE_TO_Y_VALUE).subscribe(o);
         assertTestObserverCompletedAfterDuration(AnimationConstants.DURATION_DEFAULT);
         assertEquals(TRANSLATE_TO_X_VALUE, view.getTranslationX(), 0.1f);
@@ -35,7 +34,6 @@ public class TranslateAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testTranslateToWithDuration() throws InterruptedException {
-        o.assertNotComplete();
         translateTo(view, TRANSLATE_TO_X_VALUE, TRANSLATE_TO_Y_VALUE, CUSTOM_TEST_DURATION_MS).subscribe(o);
         assertTestObserverCompletedAfterDuration(CUSTOM_TEST_DURATION_MS);
         assertEquals(TRANSLATE_TO_X_VALUE, view.getTranslationX(), 0.1f);
@@ -54,7 +52,6 @@ public class TranslateAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testTranslateQuicklyTo() throws InterruptedException {
-        o.assertNotComplete();
         translateQuicklyTo(view, TRANSLATE_TO_X_VALUE, TRANSLATE_TO_Y_VALUE).subscribe(o);
         assertTestObserverCompletedAfterDuration(AnimationConstants.DURATION_QUICK);
         assertEquals(TRANSLATE_TO_X_VALUE, view.getTranslationX(), 0.1f);
@@ -68,7 +65,6 @@ public class TranslateAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testTranslateSlowlyTo() throws InterruptedException {
-        o.assertNotComplete();
         translateSlowlyTo(view, TRANSLATE_TO_X_VALUE, TRANSLATE_TO_Y_VALUE).subscribe(o);
         assertTestObserverCompletedAfterDuration(AnimationConstants.DURATION_SLOW);
         assertEquals(TRANSLATE_TO_X_VALUE, view.getTranslationX(), 0.1f);
@@ -82,7 +78,6 @@ public class TranslateAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testTranslateBy() throws InterruptedException {
-        o.assertNotComplete();
         translateBy(view, TRANSLATE_BY_X_VALUE, TRANSLATE_BY_Y_VALUE).subscribe(o);
         assertTestObserverCompletedAfterDuration(AnimationConstants.DURATION_DEFAULT);
         assertEquals(TRANSLATE_BY_X_VALUE, view.getTranslationX(), 0.1f);
@@ -91,7 +86,6 @@ public class TranslateAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testTranslateByWithDuration() throws InterruptedException {
-        o.assertNotComplete();
         translateBy(view, TRANSLATE_BY_X_VALUE, TRANSLATE_BY_Y_VALUE, CUSTOM_TEST_DURATION_MS).subscribe(o);
         assertTestObserverCompletedAfterDuration(CUSTOM_TEST_DURATION_MS);
         assertEquals(TRANSLATE_BY_X_VALUE, view.getTranslationX(), 0.1f);
@@ -110,7 +104,6 @@ public class TranslateAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testTranslateQuicklyBy() throws InterruptedException {
-        o.assertNotComplete();
         translateQuicklyBy(view, TRANSLATE_BY_X_VALUE, TRANSLATE_BY_Y_VALUE).subscribe(o);
         assertTestObserverCompletedAfterDuration(AnimationConstants.DURATION_QUICK);
         assertEquals(TRANSLATE_BY_X_VALUE, view.getTranslationX(), 0.1f);
@@ -124,7 +117,6 @@ public class TranslateAnimationsTest extends BaseAnimationsTest {
 
     @Test
     public void testTranslateSlowlyBy() throws InterruptedException {
-        o.assertNotComplete();
         translateSlowlyBy(view, TRANSLATE_BY_X_VALUE, TRANSLATE_BY_Y_VALUE).subscribe(o);
         assertTestObserverCompletedAfterDuration(AnimationConstants.DURATION_SLOW);
         assertEquals(TRANSLATE_BY_X_VALUE, view.getTranslationX(), 0.1f);

--- a/vangogh/src/androidTest/java/com/pspdfkit/labs/vangogh/base/AnimationCompletableTest.java
+++ b/vangogh/src/androidTest/java/com/pspdfkit/labs/vangogh/base/AnimationCompletableTest.java
@@ -1,0 +1,8 @@
+package com.pspdfkit.labs.vangogh.base;
+
+/**
+ * Created by skoric on 17/11/2017.
+ */
+
+public class AnimationCompletableTest {
+}

--- a/vangogh/src/androidTest/java/com/pspdfkit/labs/vangogh/base/AnimationCompletableTest.java
+++ b/vangogh/src/androidTest/java/com/pspdfkit/labs/vangogh/base/AnimationCompletableTest.java
@@ -1,8 +1,50 @@
 package com.pspdfkit.labs.vangogh.base;
 
-/**
- * Created by skoric on 17/11/2017.
- */
+import android.support.annotation.NonNull;
+import android.support.test.runner.AndroidJUnit4;
+import android.view.View;
 
-public class AnimationCompletableTest {
+import com.pspdfkit.labs.vangogh.api.BaseAnimationsTest;
+import com.pspdfkit.labs.vangogh.rx.AnimationCompletable;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(AndroidJUnit4.class)
+public class AnimationCompletableTest extends BaseAnimationsTest {
+
+    private static final long DEFAULT_DURATION = 1500L;
+
+    @Test
+    public void testAnimationCanceledOnDispose() throws InterruptedException {
+        animate(view).subscribe(o);
+        o.await(DEFAULT_DURATION / 2, TimeUnit.MILLISECONDS);
+        o.dispose();
+        o.assertNotComplete();
+
+        // Check that animation is stopped, meaning the
+        // property values are somewhere in-between.
+        assertEquals(45f, view.getRotation(), 10f);
+        assertEquals(15f, view.getTranslationX(), 5f);
+        assertEquals(0.5f, view.getAlpha(), 0.2f);
+    }
+
+    @Test
+    public void testDoOnAnimationReady() {
+
+    }
+
+    private AnimationCompletable animate(@NonNull View view) {
+        return AnimationBuilder.forView(view)
+                .rotation(90f)
+                .translationX(30f)
+                .alpha(0f)
+                .duration(DEFAULT_DURATION)
+                .buildCompletable();
+    }
+
 }

--- a/vangogh/src/main/java/com/pspdfkit/labs/vangogh/rx/AnimationCompletable.java
+++ b/vangogh/src/main/java/com/pspdfkit/labs/vangogh/rx/AnimationCompletable.java
@@ -88,7 +88,6 @@ public final class AnimationCompletable extends Completable implements OnAnimati
     @Override
     public void onAnimationDisposed() {
         if (animator != null) {
-            animator.setListener(null);
             animator.cancel();
             animator = null;
         }

--- a/vangogh/src/main/java/com/pspdfkit/labs/vangogh/rx/AnimationCompletable.java
+++ b/vangogh/src/main/java/com/pspdfkit/labs/vangogh/rx/AnimationCompletable.java
@@ -135,7 +135,6 @@ public final class AnimationCompletable extends Completable implements OnAnimati
                 }
 
                 animator.setListener(null);
-                animator = null;
                 observer.onComplete();
             }
 
@@ -150,7 +149,6 @@ public final class AnimationCompletable extends Completable implements OnAnimati
                 }
 
                 animator.setListener(null);
-                animator = null;
                 observer.onComplete();
             }
         });

--- a/vangogh/src/main/java/com/pspdfkit/labs/vangogh/rx/AnimationCompletable.java
+++ b/vangogh/src/main/java/com/pspdfkit/labs/vangogh/rx/AnimationCompletable.java
@@ -36,6 +36,9 @@ public final class AnimationCompletable extends Completable implements OnAnimati
     /** Animator for the current running animation. */
     @Nullable private ViewPropertyAnimatorCompat animator;
 
+    /** Tracks whether the animation is still running. */
+    @Nullable private boolean isAnimationRunning = false;
+
     /**
      * Creates completable that runs provided animation once subscribed to.
      * @param animation Animation to run when subscribed.
@@ -88,7 +91,11 @@ public final class AnimationCompletable extends Completable implements OnAnimati
     @Override
     public void onAnimationDisposed() {
         if (animator != null) {
-            animator.cancel();
+            if (isAnimationRunning) {
+                animator.cancel();
+                isAnimationRunning = false;
+            }
+
             animator = null;
         }
     }
@@ -107,8 +114,10 @@ public final class AnimationCompletable extends Completable implements OnAnimati
 
         try {
             animator = startAnimation(animation);
+            isAnimationRunning = true;
         } catch (Exception e) {
             observer.onError(e);
+            isAnimationRunning = false;
         }
 
         animator.setListener(new ViewPropertyAnimatorListener() {
@@ -133,6 +142,7 @@ public final class AnimationCompletable extends Completable implements OnAnimati
                     }
                 }
 
+                isAnimationRunning = false;
                 animator.setListener(null);
                 observer.onComplete();
             }
@@ -147,6 +157,7 @@ public final class AnimationCompletable extends Completable implements OnAnimati
                     }
                 }
 
+                isAnimationRunning = false;
                 animator.setListener(null);
                 observer.onComplete();
             }

--- a/vangogh/src/main/java/com/pspdfkit/labs/vangogh/rx/AnimationCompletable.java
+++ b/vangogh/src/main/java/com/pspdfkit/labs/vangogh/rx/AnimationCompletable.java
@@ -88,8 +88,8 @@ public final class AnimationCompletable extends Completable implements OnAnimati
     @Override
     public void onAnimationDisposed() {
         if (animator != null) {
-            animator.cancel();
             animator.setListener(null);
+            animator.cancel();
             animator = null;
         }
     }

--- a/vangogh/src/main/java/com/pspdfkit/labs/vangogh/rx/AnimationDisposable.java
+++ b/vangogh/src/main/java/com/pspdfkit/labs/vangogh/rx/AnimationDisposable.java
@@ -1,17 +1,12 @@
 package com.pspdfkit.labs.vangogh.rx;
 
+import io.reactivex.android.MainThreadDisposable;
 import io.reactivex.annotations.NonNull;
-import io.reactivex.disposables.Disposable;
-
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Represents disposable resource for animations.
  */
-public final class AnimationDisposable implements Disposable {
-
-    /** Tracks whether this disposable has been disposed or not. */
-    @NonNull private final AtomicBoolean isDisposed = new AtomicBoolean();
+public final class AnimationDisposable extends MainThreadDisposable {
 
     /** Provided listener through which {@link AnimationDisposable} can notify that it has been disposed. */
     @NonNull private final OnAnimationDisposedListener onAnimationDisposedListener;
@@ -24,20 +19,11 @@ public final class AnimationDisposable implements Disposable {
         this.onAnimationDisposedListener = onAnimationDisposedListener;
     }
 
-    /** {@inheritDoc} */
     @Override
-    public void dispose() {
-        if (isDisposed.compareAndSet(false, true)) {
-            if (onAnimationDisposedListener != null) {
-                onAnimationDisposedListener.onAnimationDisposed();
-            }
+    protected void onDispose() {
+        if (onAnimationDisposedListener != null) {
+            onAnimationDisposedListener.onAnimationDisposed();
         }
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public boolean isDisposed() {
-        return isDisposed.get();
     }
 
 }


### PR DESCRIPTION
## Fixes #10 

Avoids nulling out the animator object in the callback which prevents `NullPointerException` when disposing the completable.

## To do - resolves #11

* [x] Test base class `AnimationCompletable`