### PR TITLE
Make animations shorter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ before_script:
 notifications:
   email: true
 
+sudo: false
+
 cache:
   directories:
     - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ android:
   components:
     - platform-tools
     - tools
-    - android-21
-    - build-tools-24.0.2
+    - android-22
+    - build-tools-23.0.3
     - extra-android-m2repository
     - extra-android-support
     - sys-img-armeabi-v7a-android-22
@@ -19,7 +19,7 @@ before_install:
 - chmod +x gradlew
 
 before_script:
-  - echo no | android create avd --force -n test -t android-21 --abi armeabi-v7a
+  - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
   - emulator -avd test -no-skin -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 language: android
 jdk: oraclejdk8
 
@@ -5,8 +7,8 @@ android:
   components:
     - platform-tools
     - tools
-    - android-22
-    - build-tools-23.0.3
+    - android-21
+    - build-tools-24.0.2
     - extra-android-m2repository
     - extra-android-support
     - sys-img-armeabi-v7a-android-22
@@ -17,15 +19,13 @@ before_install:
 - chmod +x gradlew
 
 before_script:
-  - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
+  - echo no | android create avd --force -n test -t android-21 --abi armeabi-v7a
   - emulator -avd test -no-skin -no-audio -no-window &
   - android-wait-for-emulator
-  - adb shell input keyevent 82
+  - adb shell input keyevent 82 &
 
 notifications:
   email: true
-
-sudo: false
 
 cache:
   directories:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 Change Log
 ==========
 
-Version 0.1.2 *(2017-x-y)*
+Version 0.2.0 *(2017-x-y)*
 ----------------------------
+* *Importat:* Duration is no more pre-determined by the library but uses the default duration defined by Android in `ValueAnimator`. Quick animations use 60% of that duration value and slow animations use 300%.
 * Adds "shake" animations. ([#13](https://github.com/PSPDFKit-labs/VanGogh/issues/13))
     * Adds `ShakeAnimations` class with `shake()`, `shakeQuickly()` and `shakeSlowly()` methods.
 * Adds "show as toast" animations. ([#15](https://github.com/PSPDFKit-labs/VanGogh/issues/15))
@@ -14,7 +15,6 @@ Version 0.1.2 *(2017-x-y)*
 Version 0.1.1 *(2017-11-20)*
 ----------------------------
 * Fixes `NullPointerException` being thrown when animation disposed midway. ([#10](https://github.com/PSPDFKit-labs/VanGogh/issues/10))
-
 
 Version 0.1.0 *(2017-11-09)*
 ----------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Change Log
 
 Version 0.2.0 *(2017-x-y)*
 ----------------------------
-* *Importat:* Duration is no more pre-determined by the library but uses the default duration defined by Android in `ValueAnimator`. Quick animations use 60% of that duration value and slow animations use 300%.
+* *Important:* Duration is no more pre-determined by the library but uses the default duration defined by Android in `ValueAnimator`. Quick animations use 60% of that duration value and slow animations use 300%.
 * Adds "shake" animations. ([#13](https://github.com/PSPDFKit-labs/VanGogh/issues/13))
     * Adds `ShakeAnimations` class with `shake()`, `shakeQuickly()` and `shakeSlowly()` methods.
 * Adds "show as toast" animations. ([#15](https://github.com/PSPDFKit-labs/VanGogh/issues/15))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Change Log
 
 Version 0.2.0 *(2017-x-y)*
 ----------------------------
-* *Important:* Duration is no more pre-determined by the library but uses the default duration defined by Android in `ValueAnimator`. Quick animations use 60% of that duration value and slow animations use 300%.
+* *Important:* Duration is no more pre-determined by the library but uses the default duration defined by Android in `ValueAnimator`. Quick animations use 60% of that duration value and slow animations use 300%. ([#20](https://github.com/PSPDFKit-labs/VanGogh/issues/20))
 * Adds "shake" animations. ([#13](https://github.com/PSPDFKit-labs/VanGogh/issues/13))
     * Adds `ShakeAnimations` class with `shake()`, `shakeQuickly()` and `shakeSlowly()` methods.
 * Adds "show as toast" animations. ([#15](https://github.com/PSPDFKit-labs/VanGogh/issues/15))

--- a/vangogh/src/main/java/com/pspdfkit/labs/vangogh/api/AnimationConstants.java
+++ b/vangogh/src/main/java/com/pspdfkit/labs/vangogh/api/AnimationConstants.java
@@ -1,5 +1,6 @@
 package com.pspdfkit.labs.vangogh.api;
 
+import android.animation.ValueAnimator;
 import android.view.animation.AccelerateDecelerateInterpolator;
 import android.view.animation.Interpolator;
 
@@ -14,14 +15,14 @@ final class AnimationConstants {
     /** Full invisibility alpha level. */
     static final float ALPHA_INVISIBLE = 0f;
 
+    /** Default animation duration in ms. */
+    static final long DURATION_DEFAULT = new ValueAnimator().getDuration();
+
     /** Quick animation duration in ms. */
-    static final long DURATION_QUICK = 300L;
+    static final long DURATION_QUICK = (long) (DURATION_DEFAULT * 0.6f);
 
     /** Slow animation duration in ms. */
-    static final long DURATION_SLOW = 1500L;
-
-    /** Default animation duration in ms. */
-    static final long DURATION_DEFAULT = 1000L;
+    public static final long DURATION_SLOW = DURATION_DEFAULT * 3;
 
     /** Default interpolator used with animations if not specified otherwise. */
     static final Interpolator INTERPOLATOR = new AccelerateDecelerateInterpolator();

--- a/vangogh/src/main/java/com/pspdfkit/labs/vangogh/api/FadeAnimations.java
+++ b/vangogh/src/main/java/com/pspdfkit/labs/vangogh/api/FadeAnimations.java
@@ -59,7 +59,7 @@ public final class FadeAnimations {
     }
 
     /**
-     * Fades in the given view quickly (duration = {@value AnimationConstants#DURATION_QUICK}).
+     * Fades in the given view quickly.
      * @param view View to fade in.
      * @return Completable which starts animation once subscribed to.
      */
@@ -68,7 +68,7 @@ public final class FadeAnimations {
     }
 
     /**
-     * Fades in the given view quickly (duration = {@value AnimationConstants#DURATION_QUICK}).
+     * Fades in the given view quickly.
      * @param view         View to fade in.
      * @param interpolator Interpolator to use in animation.
      * @return Completable which starts animation once subscribed to.
@@ -78,7 +78,7 @@ public final class FadeAnimations {
     }
 
     /**
-     * Fades in the given view slowly (duration = {@value AnimationConstants#DURATION_SLOW}).
+     * Fades in the given view slowly.
      * @param view View to fade in.
      * @return Completable which starts animation once subscribed to.
      */
@@ -87,7 +87,7 @@ public final class FadeAnimations {
     }
 
     /**
-     * Fades in the given view slowly (duration = {@value AnimationConstants#DURATION_SLOW}).
+     * Fades in the given view slowly.
      * @param view         View to fade in.
      * @param interpolator Interpolator to use in animation.
      * @return Completable which starts animation once subscribed to.
@@ -137,7 +137,7 @@ public final class FadeAnimations {
     }
 
     /**
-     * Fades out the given view quickly (duration = {@value AnimationConstants#DURATION_QUICK}).
+     * Fades out the given view quickly.
      * @param view View to fade out.
      * @return Completable which starts animation once subscribed to.
      */
@@ -146,7 +146,7 @@ public final class FadeAnimations {
     }
 
     /**
-     * Fades out the given view quickly (duration = {@value AnimationConstants#DURATION_QUICK}).
+     * Fades out the given view quickly.
      * @param view         View to fade out.
      * @param interpolator Interpolator to use in animation.
      * @return Completable which starts animation once subscribed to.
@@ -156,7 +156,7 @@ public final class FadeAnimations {
     }
 
     /**
-     * Fades out the given view slowly (duration = {@value AnimationConstants#DURATION_SLOW}).
+     * Fades out the given view slowly.
      * @param view View to fade out.
      * @return Completable which starts animation once subscribed to.
      */
@@ -165,7 +165,7 @@ public final class FadeAnimations {
     }
 
     /**
-     * Fades out the given view slowly (duration = {@value AnimationConstants#DURATION_SLOW}).
+     * Fades out the given view slowly.
      * @param view         View to fade out.
      * @param interpolator Interpolator to use in animation.
      * @return Completable which starts animation once subscribed to.


### PR DESCRIPTION
## Resolves #20 

Uses default Android duration for animations. Thus, quick animations are 0.6 * default_animation_ms, and slow animations are 3 * default_animation_ms.